### PR TITLE
HACK to serve large exports from local storage

### DIFF
--- a/nginx/kobo-docker-scripts/templates/uwsgi_pass.conf.tmpl
+++ b/nginx/kobo-docker-scripts/templates/uwsgi_pass.conf.tmpl
@@ -13,3 +13,6 @@ include /etc/nginx/uwsgi_params;
 # Support longer query strings. See issue #147
 uwsgi_buffers 8 16k;
 uwsgi_buffer_size 16k;
+
+# HACK for large exports without S3 storage
+uwsgi_buffering off;

--- a/uwsgi/kc_uwsgi.ini
+++ b/uwsgi/kc_uwsgi.ini
@@ -7,7 +7,8 @@ logto           = $(KOBOCAT_LOGS_DIR)/uwsgi.log
 
 # process related settings
 master              = true
-harakiri            = $(KC_UWSGI_HARAKIRI)
+# HACK for large exports without S3 storage
+#harakiri            = $(KC_UWSGI_HARAKIRI)
 worker-reload-mercy = $(KC_UWSGI_WORKER_RELOAD_MERCY)
 
 # monitoring (use with `uwsgitop :1717`, for example)


### PR DESCRIPTION
Workaround for downloads failing after 1 GB. Disables script execution time limits and buffering; not for use with high-traffic sites